### PR TITLE
Packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+.PHONY: pkg
+
 default:
 	$(MAKE) deps
 	$(MAKE) all
@@ -38,4 +40,6 @@ test-all:
 check:
 	$(MAKE) test
 all:
-	bash -c "./scripts/build.sh"
+	bash -c "./scripts/build.sh code"
+pkg:
+	bash -c "./scripts/build.sh pkg"

--- a/dbi/dbi.go
+++ b/dbi/dbi.go
@@ -27,13 +27,6 @@ import (
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
 )
 
-const (
-	// Name of plugin
-	Name = "dbi"
-	// Version of plugin
-	Version = 5
-)
-
 // DbiPlugin holds information about the configuration database and defined queries
 type DbiPlugin struct {
 	databases   map[string]*dtype.Database

--- a/dbi/metadata.go
+++ b/dbi/metadata.go
@@ -1,0 +1,8 @@
+package dbi
+
+const (
+	// Name of plugin
+	Name = "dbi"
+	// Version of plugin. This is used in build.sh to set the pkg version
+	Version = 5
+)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,35 +32,55 @@ plugin_name=${__proj_dir##*/}
 build_dir="${__proj_dir}/build"
 pkg_dir="${__proj_dir}/pkg"
 go_build=(go build -ldflags "-w")
-
-_info "project path: ${__proj_dir}"
-_info "plugin name: ${plugin_name}"
-
-export CGO_ENABLED=0
-
-# rebuild binaries:
-_debug "removing: ${build_dir:?}/*"
-rm -rf "${build_dir:?}/"*
-
-_debug "removing: ${pkg_dir:?}/*"
-rm -rf "${pkg_dir:?}/"*
-
-_info "building plugin: ${plugin_name}"
 export GOOS=linux
 export GOARCH=amd64
-mkdir -p "${build_dir}/${GOOS}/x86_64"
-"${go_build[@]}" -o "${build_dir}/${GOOS}/x86_64/${plugin_name}" . || exit 1
 
-# build package for the Intel agent
-mkdir -p pkg/tmp/opt/snap/plugins
-cp -f "${build_dir}/${GOOS}/x86_64/${plugin_name}" pkg/tmp/opt/snap/plugins
-(cd ${pkg_dir} && \
-fpm -s dir -C tmp -t deb \
-  -n ${plugin_name} \
-  -m "Papertrails Ops <ops@papertrail.com>" \
-  -v 5 \
-  -d snap-telemetry \
-  --url "https://www.papertrail.com" \
-  --description "DBI plugin for the Intel snap agent" \
-  --vendor "Papertrail" \
-  opt/snap/plugins/snap-plugin-collector-dbi)
+build_type="code"
+if [ $# -gt 0 ]; then
+  build_type="$1"
+fi
+
+if [ "$build_type" = "code" ]; then
+  _info "project path: ${__proj_dir}"
+  _info "plugin name: ${plugin_name}"
+
+  export CGO_ENABLED=0
+
+  # rebuild binaries:
+  _debug "removing: ${build_dir:?}/*"
+  rm -rf "${build_dir:?}/"*
+
+  _info "building plugin: ${plugin_name}"
+  mkdir -p "${build_dir}/${GOOS}/x86_64"
+  "${go_build[@]}" -o "${build_dir}/${GOOS}/x86_64/${plugin_name}" . || exit 1
+
+elif [ "$build_type" = "pkg" ]; then
+  # builds a standalone package
+  gem list | grep fpm >/dev/null 2>&1 || { \
+	  echo "\033[1;33mfpm is not installed. See https://github.com/jordansissel/fpm\033[m"; \
+	  echo "$$ gem install fpm"; \
+	  exit 1; \
+	}
+
+  _debug "removing: ${pkg_dir:?}/*"
+  rm -rf "${pkg_dir:?}/"*
+
+  version_num=$(tr -s [" "\\t] [" "" "]  < "${__proj_dir}/dbi/metadata.go" | grep "Version = " | cut -d" " -f4)
+  mkdir -p pkg/tmp/opt/snap_plugins
+  cp -f "${build_dir}/${GOOS}/x86_64/${plugin_name}" pkg/tmp/opt/snap_plugins
+  (cd ${pkg_dir} && \
+  fpm -s dir -C tmp -t deb \
+    -n ${plugin_name} \
+    -m "Papertrails Ops <ops@papertrail.com>" \
+    -v ${version_num} \
+    -d "snap-telemetry|appoptics-snaptel" \
+    --license "Apache" \
+    --url "https://www.papertrail.com" \
+    --description "DBI plugin for the Intel snap agent" \
+    --vendor "Papertrail" \
+    opt/snap_plugins/snap-plugin-collector-dbi)
+
+else
+  echo "Must pass in a build type of either code or pkg"
+  exit 1
+fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,7 @@ __proj_dir="$(dirname "$__dir")"
 
 plugin_name=${__proj_dir##*/}
 build_dir="${__proj_dir}/build"
+pkg_dir="${__proj_dir}/pkg"
 go_build=(go build -ldflags "-w")
 
 _info "project path: ${__proj_dir}"
@@ -41,8 +42,25 @@ export CGO_ENABLED=0
 _debug "removing: ${build_dir:?}/*"
 rm -rf "${build_dir:?}/"*
 
+_debug "removing: ${pkg_dir:?}/*"
+rm -rf "${pkg_dir:?}/"*
+
 _info "building plugin: ${plugin_name}"
 export GOOS=linux
 export GOARCH=amd64
 mkdir -p "${build_dir}/${GOOS}/x86_64"
 "${go_build[@]}" -o "${build_dir}/${GOOS}/x86_64/${plugin_name}" . || exit 1
+
+# build package for the Intel agent
+mkdir -p pkg/tmp/opt/snap/plugins
+cp -f "${build_dir}/${GOOS}/x86_64/${plugin_name}" pkg/tmp/opt/snap/plugins
+(cd ${pkg_dir} && \
+fpm -s dir -C tmp -t deb \
+  -n ${plugin_name} \
+  -m "Papertrails Ops <ops@papertrail.com>" \
+  -v 5 \
+  -d snap-telemetry \
+  --url "https://www.papertrail.com" \
+  --description "DBI plugin for the Intel snap agent" \
+  --vendor "Papertrail" \
+  opt/snap/plugins/snap-plugin-collector-dbi)


### PR DESCRIPTION
Plonks the plugin on the disk and doesn't attempt to enable it. This plugin will probably be integrated into the AO agent in the future so I was thinking that enabling could be performed via Salt for now.